### PR TITLE
Added additional mcu for a CTRL with a different chip id.

### DIFF
--- a/mdloader_common.c
+++ b/mdloader_common.c
@@ -35,7 +35,10 @@ appinfo_t appinfo;      //Applet application information from end of applet bina
 mcu_t mcus[] = {
       //Name,       Chip ID     Chip ID,    Program Memory, Data Memory,    Program Addr,   Data Addr
       //            Address                 (FLASH_SIZE)    (HSRAM_SIZE)    (FLASH_ADDR)    (HSRAM_ADDR)
+    // Massdrop CTRL
     { "SAMD51J18A", 0x41002018, 0x60060006, 0x40000,        0x20000,        0x00000000,     0x20000000},
+    // Drop CTRL High-Profile
+    { "SAMD51J18A", 0x41002018, 0x60060306, 0x40000,        0x20000,        0x00000000,     0x20000000},
 };
 
 mcu_t *mcu; //Pointer to mcus entry if found


### PR DESCRIPTION
My new CTRL High-Profile had a different chip ID than what was listed in the mcu structure, so I added an addition entry.  Tested using mdloader to write a new keymap against both my new CTRL and the original low-profile without issue.