### PR TITLE
Fix typo in temporary applet name fix

### DIFF
--- a/mdloader_common.c
+++ b/mdloader_common.c
@@ -757,7 +757,7 @@ int main(int argc, char *argv[])
     strlower(mcu->name);
 
     //sprintf(appletfname, "applet-flash-%s.bin", mcu->name);
-    sprintf(appletfname, "applet-flash-samd51j19a.bin", mcu->name);  //temporary fix
+    sprintf(appletfname, "applet-flash-samd51j18a.bin", mcu->name);  //temporary fix
       
     printf("Applet file: %s\n", appletfname);
 


### PR DESCRIPTION
The recent change to mdloader to support more chip IDs also changed the applet name to a constant to reuse the ATSAMD51J18A applet for all chips. However, the change references an applet for the ATSAMD51J19A, which is not part of this repo yet. 

This PR corrects the name of the applet to the file that exists in this repo.